### PR TITLE
Fix keeper on create_roles module

### DIFF
--- a/modules/create_roles/main.tf
+++ b/modules/create_roles/main.tf
@@ -1,9 +1,11 @@
-
+locals {
+  roles = { for role in var.roles_list : role.name => role }
+}
 resource "random_password" "user-password" {
-  for_each = { for role in var.roles_list : role.name => role }
+  for_each = local.roles
 
   keepers = {
-    name = each.key
+    name = each.value["name"]
   }
 
   length  = var.password_length
@@ -11,7 +13,7 @@ resource "random_password" "user-password" {
 }
 
 resource "postgresql_role" "role" {
-  for_each = { for role in var.roles_list : role.name => role }
+  for_each = local.roles
 
   name            = each.key
   superuser       = lookup(each.value, "superuser", false)

--- a/modules/create_roles/main.tf
+++ b/modules/create_roles/main.tf
@@ -1,11 +1,12 @@
 locals {
   roles = { for role in var.roles_list : role.name => role }
 }
+
 resource "random_password" "user-password" {
   for_each = local.roles
 
   keepers = {
-    name = each.value["name"]
+    name = each.key
   }
 
   length  = var.password_length

--- a/modules/create_roles/outputs.tf
+++ b/modules/create_roles/outputs.tf
@@ -1,9 +1,8 @@
-
-output "roles_created"{
-    value = values(postgresql_role.role)[*].name
+output "roles_created" {
+  value = values(postgresql_role.role)[*].name
 }
 
 output "roles_password" {
-    value     = values(random_password.user-password)[*].result
-    sensitive = true
+  value     = values(random_password.user-password)[*].result
+  sensitive = true
 }


### PR DESCRIPTION
When I created, for the first time, new roles, the module `create_roles` wasn't creating a random password for the users.

After debugging, it looks like the `keepers` property on `random_password.user-password` should reference `each.value["name"]` because `each.key` will always be `name`:

Example input for the module:
```
"roles_list": [
  {
    "name": "bff-abc"
  },
  {
    "name": "bigbrother-abc"
  }
]
```

Using `each.key` as `keepers` will always be `name`, and won't trigger a new password. Using `each.value["name"]` will recreate a new password if the `name` changes.